### PR TITLE
Merge latest changes

### DIFF
--- a/IBOS.asm
+++ b/IBOS.asm
@@ -272,7 +272,7 @@ prvPrintBufferFreeHigh = prv82 + &08
 prvPrintBufferSizeLow  = prv82 + &09
 prvPrintBufferSizeMid  = prv82 + &0A
 prvPrintBufferSizeHigh = prv82 + &0B
-prvPrintBufferBankList = prv83 + &18 ; 4 bytes
+prvPrintBufferBankList = prv83 + &18 ; 4 byte list of sideways RAM banks used by printer buffer, &FF for "no bank in this position"
 
 LDBE6       = &DBE6
 LDC16       = &DC16
@@ -2066,15 +2066,16 @@ GUARD	&C000
             ORA #&40
             STA prvPrintBufferBankList
             LDA #&FF
-            STA prv83+&19
-            STA prv83+&1A
-            STA prv83+&1B
+            STA prvPrintBufferBankList + 1
+            STA prvPrintBufferBankList + 2
+            STA prvPrintBufferBankList + 3
 .L8D5A      LDA prvPrintBufferBankList
             CMP #&FF
             BEQ L8D46
             AND #&F0
             CMP #&40
-            BNE L8D8D
+            BNE bufferInPrivateRam
+            ; Buffer is in sideways RAM, not private RAM.
             JSR LBFBD
             STA prv82+&0C
             LDA #&B0
@@ -2089,7 +2090,8 @@ GUARD	&C000
             SBC prv82+&0C
             STA prvPrintBufferSizeMid
             JMP purgePrintBuffer
-			
+
+.bufferInPrivateRam
 .L8D8D      LDA #&00
             STA prvPrintBufferSizeLow
             STA prvPrintBufferSizeMid
@@ -2133,7 +2135,7 @@ GUARD	&C000
             JMP L8E07								;and finish
 			
 .L8DE8      LDX #&01								;starting with the first RAM bank
-            JSR L8E8C								;write 'k in Shadow RAM '
+            JSR L8E8C								;write 'k in Sideways RAM '
             LDY #&00
 .L8DEF      LDA prvPrintBufferBankList,Y								;get RAM bank number from Private memory
             BMI L8E02								;if nothing in private memory then finish, otherwise

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -7977,6 +7977,7 @@ ibosCNPVIndex = 6
             ;   &107,S  A stacked by romCodeStubCallIBOS
             ;   &108,S  return address from "JSR ramCodeStubCallIBOS" (low)
             ;   &109,S  return address from "JSR ramCodeStubCallIBOS" (high)
+            ;   &10A,S  x (caller's data; nothing to do with us)
             ; The low byte of the return address at &108,S will be the address
             ; of the JSR ramCodeStubCallIBOS plus 2. We mask off the low bits
             ; (which are sufficient to distinguish the 7 different callers) and
@@ -7996,11 +7997,13 @@ ibosCNPVIndex = 6
 ; At this point the stack should be exactly as described in the big comment in
 ; vectorEntry; note that this code is reached via JMP so there's no extra return
 ; address on the stack as there is in restoreOrigVectorRegs.
+.returnFromVectorHandler
+{
 ; SFTODO: This is really just shuffling the stack down to remove the return
 ; address from "JSR ramCodeStubCallIBOS"; can we rewrite it more compactly using
 ; a loop?
 .LB9E9      TSX
-            LDA L0107,X ; get A stacked by romCodeStubCallIBOS
+            LDA L0107,X
             STA L0109,X
             LDA L0106,X
             STA L0108,X
@@ -8024,6 +8027,7 @@ ibosCNPVIndex = 6
             ;   &105,S  previously paged in ROM bank stacked by romCodeStubCallIBOS
             ;   &106,S  flags stacked by romCodeStubCallIBOS
             ;   &107,S  A stacked by romCodeStubCallIBOS
+            ;   &108,S  x (caller's data; nothing to do with us)
             ; We now restore Y and X and RTS from "JSR vectorEntry" in ramCodeStub,
             ; which will restore the previously paged in ROM, the flags and then A,
             ; so the vector's caller will see the Z/N flags reflecting A, but
@@ -8033,6 +8037,7 @@ ibosCNPVIndex = 6
             PLA
             TAX
             RTS
+}
 
 ; Patch the return address further up the stack (SFTODO: be good to work out
 ; what the stack looks like here) to return to the Ath vector in
@@ -8164,7 +8169,7 @@ ibosCNPVIndex = 6
             LDA #&98
 }
 .LBACB      JSR LB9AA
-            JMP LB9E9
+            JMP returnFromVectorHandler
 
 ; Read top of user memory (http://beebwiki.mdfs.net/OSBYTE_%2684)
 .osbyte84Handler
@@ -8254,7 +8259,7 @@ ibosCNPVIndex = 6
             JSR LB948
             JSR LBB51
             JSR LB9AA
-            JMP LB9E9
+            JMP returnFromVectorHandler
 
 .LBB67      LDA #ibosWORDVIndex
             JMP returnToParentVectorTblEntry
@@ -8269,7 +8274,7 @@ ibosCNPVIndex = 6
             JSR restoreOrigVectorRegs
             JSR jmpParentRDCHV
             JSR LB9AA
-            JMP LB9E9
+            JMP returnFromVectorHandler
 }
 			
 .LBB7E      JMP (L08B1)
@@ -8360,7 +8365,7 @@ ibosCNPVIndex = 6
             LDA #&00
             STA L03A5
 .^LBC29      PLA
-            JMP LB9E9
+            JMP returnFromVectorHandler
 }
 			
 .LBC2D      LDA L00D0								;get VDU status
@@ -8605,7 +8610,7 @@ ibosCNPVIndex = 6
             NOT_AND romselPrvEn
             STA &F4
             STA SHEILA+&30
-            JMP LB9E9
+            JMP returnFromVectorHandler
 
 .cnpvHandler
 {

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -2653,9 +2653,9 @@ GUARD	&C000
             LDA L00AA
             CLC
             JSR L86DE								;Convert binary number to numeric characters and write characters to screen
-            LDA #&3A								;':'
+            LDA #':'
             JSR OSWRCH								;write to screen
-.L91B9      LDA #&20								;' '
+.L91B9      LDA #' '
             JMP OSWRCH								;write to screen
 			
 ;*PRINT Command
@@ -6948,15 +6948,15 @@ GUARD	&C000
             CMP #&2B								;'+'
             BNE LB285
             LDX #&0B
-.LB285      CMP #&2D								;'-'
+.LB285      CMP #'-'
             BNE LB28B
             LDX #&0C
-.LB28B      CMP #&2A								;'*'
+.LB28B      CMP #'*'
             BNE LB291
             LDX #&0A
-.LB291      CMP #&31								;'1'
+.LB291      CMP #'1'
             BCC LB29C
-            CMP #&3A								;':' Between 0..9
+            CMP #':'								;':' Between 0..9
             BCS LB29C
             AND #&0F
             TAX

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -1938,7 +1938,7 @@ GUARD	&C000
             JMP L8FA3
 			
 .L8C86      JSR PrvEn								;switch in private RAM
-            JSR LBF90
+            JSR purgePrintBuffer
             JMP L8E0A
 			
 .L8C8F      LDX #&47
@@ -2059,7 +2059,7 @@ GUARD	&C000
             LDA prv82+&0E
             SBC prv82+&0C
             STA prvPrintBufferSizeHigh
-            JMP LBF90
+            JMP purgePrintBuffer
 			
 .L8D8D      LDA #&00
             STA prvPrintBufferSizeLow
@@ -2086,7 +2086,7 @@ GUARD	&C000
             LDA #&C0
             STA prv82+&0E
             STX prv82+&0F
-            JMP LBF90
+            JMP purgePrintBuffer
 			
 .L8DCA      LDA prv82+&0B
             LSR A
@@ -8653,7 +8653,7 @@ ibosCNPVIndex = 6
             LDX #&47
             JSR L8870								;read data from Private RAM &83xx (Addr = X, Data = A)
             BEQ LBE16
-            JSR LBF90
+            JSR purgePrintBuffer
 .LBE16      JMP setRamselAClearPrvenReturnFromVectorHandler
 
 .cnpvCount
@@ -8707,7 +8707,7 @@ ibosCNPVIndex = 6
             STA prv83+&19
             STA prv83+&1A
             STA prv83+&1B
-.LBE7B      JSR LBF90
+.LBE7B      JSR purgePrintBuffer
             JSR PrvDis								;switch out private RAM
             LDY #&0F								;relocation code
 .LBE83      LDA LBF5A,Y
@@ -8876,6 +8876,8 @@ ibosCNPVIndex = 6
             PLA
             JMP L0380			;This code is relocated from .LBF5A
 
+.purgePrintBuffer
+{
 .LBF90      LDA #&00
             STA prv82+&00
             STA prv82+&03
@@ -8892,6 +8894,7 @@ ibosCNPVIndex = 6
             LDA prv82+&0B
             STA prvPrintBufferStatus
             RTS
+}
 			
 .LBFBD      LDX #&45
             JSR L8870								;read data from Private RAM &83xx (Addr = X, Data = A)

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -2432,7 +2432,6 @@ GUARD	&C000
 ; to try to reflect this, but it's a bit misleading as we are paging out the *whole*
 ; private 12K.
 ;Switch out Shadow / Private memory SFTODO: see my comment on PrvEn
-
 ; SFTODO: I'm tempted to get rid of the PrvDis label but I'll leave it for now
 .pageOutPrv1
 .PrvDis	  PHA
@@ -8826,6 +8825,8 @@ ibosCNPVIndex = 6
             CMP #&90
             BCC LBFCA
             CMP #&AC
+            ; SFTODO: We could BCC to a *different* RTS (there's one just above)
+            ; and make the JSR:RTS below into a JMP, saving a byte.
             BCC LBFCF
 .LBFCA      LDA #&AC
             JSR L8864								;write data to Private RAM &83xx (Addr = X, Data = A)
@@ -8847,3 +8848,8 @@ SAVE "IBOS-01.rom", start, end
 ; SFTODO: Eventually it might be good to get rid of all the Lxxxx address
 ; labels, but I'm keeping them around for now as they might come in handy and
 ; it's much easier to take them out than to put them back in...
+
+; SFTODO: Is there any reason we can't always page the private RAM in and out as
+; a 12K chunk? If we don't need the fine-grained control on offer, we might be
+; able to remove some subroutines to page in/out different chunks and free up
+; some space for other code.

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -7993,9 +7993,13 @@ ibosCNPVIndex = 6
             TAX
             RTS
 }
-			
+
+; Aries/Watford shadow RAM access (http://beebwiki.mdfs.net/OSBYTE_%266F)
+.osbyte6FHandler
+{
 .LBA34      JSR L8A7B
             JMP LBACB
+}
 
 ; SFTODO: What's this doing?
 .LBA3A      CPX #&00
@@ -8034,10 +8038,15 @@ ibosCNPVIndex = 6
 .bytevHandler
 {
 .LBA68	  JSR LB994
+; SFTODO: I am assuming that JSR peeks the original A,X,Y off stack - it does
+; something roughly along those lines, but I haven't checked what exactly is on
+; the stack yet.
+; SFTODO: Is there any chance of saving a few bytes by converting this to a
+; jump table?
             CMP #&6F
-            BEQ LBA34
+            BEQ osbyte6FHandler
             CMP #&98
-            BEQ LBA96
+            BEQ osbyte98Handler
             CMP #&87
             BEQ LBA90
             CMP #&84
@@ -8056,7 +8065,10 @@ ibosCNPVIndex = 6
 			
 .LBA90      JSR LB948
             JMP LBB1C
-			
+
+; Examine buffer status (http://beebwiki.mdfs.net/OSBYTE_%2698)
+.osbyte98Handler
+{
 .LBA96      JSR jmpParentBYTEV
             BCS LBACB
             LDA &037F
@@ -8082,9 +8094,10 @@ ibosCNPVIndex = 6
             LDA (L00FA),Y
             TAY
             LDA #&98
+}
 .LBACB      JSR LB9AA
             JMP LB9E9
-			
+
 .LBAD1      PHA
             LDA L00D0
             AND #&10

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -8052,9 +8052,9 @@ ibosCNPVIndex = 6
             CMP #&84
             BEQ osbyte84Handler
             CMP #&85
-            BEQ LBADC
+            BEQ osbyte85Handler
             CMP #&8E
-            BEQ LBAF1
+            BEQ osbyte8EHandler
             CMP #&00
             BEQ LBB00
             CMP #&81
@@ -8102,6 +8102,7 @@ ibosCNPVIndex = 6
 .LBACB      JSR LB9AA
             JMP LB9E9
 
+; Read top of user memory (http://beebwiki.mdfs.net/OSBYTE_%2684)
 .osbyte84Handler
 {
 .LBAD1      PHA
@@ -8111,7 +8112,10 @@ ibosCNPVIndex = 6
             PLA
             JMP LBB1C
 }
-			
+
+; Read base of display RAM for a given mode (http://beebwiki.mdfs.net/OSBYTE_%2685)
+.osbyte85Handler
+{
 .LBADC      PHA
             TXA
             BMI LBAE9
@@ -8119,18 +8123,23 @@ ibosCNPVIndex = 6
             BEQ LBAE9
             PLA
             JMP LBB1C
+}
 			
 .LBAE9      PLA
             LDX #&00
             LDY #&80
             JMP LBACB
-			
+
+; Enter language ROM (http://beebwiki.mdfs.net/OSBYTE_%268E)
+.osbyte8EHandler
+{
 .LBAF1      LDA #&8F								;Select Issue paged ROM service request
             LDX #&2A								;Service type &2A
             LDY #&00
             JSR OSBYTE								;Execute Issue paged ROM service request
             JSR LB994
             JMP LBB1C
+}
 			
 .LBB00      TXA
             PHA

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -253,6 +253,19 @@ prv83       = &8300
 ; The printer buffer can be up to 64K in size; 64K is &10000 bytes so we need to
 ; use a 24-bit representation and we therefore have high, middle and low bytes
 ; here instead of just high and low bytes.
+; SFTODO: I'm not exactly sure what's happening, but SFTODOA and SFTODOB are a
+; pair of three byte counters, probably something to do with the printer buffer.
+; The 'AB' variables here are used where code is accessing either A or B
+; depending on whether X is 0 or 3.
+SFTODOALOW = prv82 + &00
+SFTODOAMID = prv82 + &01
+SFTODOAHIGH = prv82 + &02
+SFTODOABLOW = SFTODOALOW
+SFTODOABMID = SFTODOAMID
+SFTODOABHIGH = SFTODOAHIGH
+SFTODOBLOW = prv82 + &03
+SFTODOBMID = prv82 + &04
+SFTODOBHIGH = prv82 + &05
 prvPrintBufferFreeLow  = prv82 + &06
 prvPrintBufferFreeMid  = prv82 + &07
 prvPrintBufferFreeHigh = prv82 + &08
@@ -8766,13 +8779,13 @@ ibosCNPVIndex = 6
 .^LBEB2     LDX #&03
             BNE LBEB8 ; always branch
 .^LBEB6     LDX #&00
-.LBEB8      INC prv82+&00,X
+.LBEB8      INC SFTODOABLOW,X
             BNE LBEE8
-            INC prv82+&01,X
-            LDA prv82+&01,X
+            INC SFTODOABMID,X
+            LDA SFTODOABMID,X
             CMP prv82+&0E
             BCC LBEE8
-            LDY prv82+&02,X
+            LDY SFTODOABHIGH,X
             INY
             CPY #&04
             BCC LBED2
@@ -8781,11 +8794,11 @@ ibosCNPVIndex = 6
             BPL LBED9
             LDY #&00
 .LBED9      TYA
-            STA prv82+&02,X
+            STA SFTODOABHIGH,X
             LDA #&00
-            STA prv82+&00,X
+            STA SFTODOABLOW,X
             LDA prv82+&0C
-            STA prv82+&01,X
+            STA SFTODOABMID,X
 .LBEE8      RTS
 }
 
@@ -8905,11 +8918,11 @@ ramRomAccessSubroutineVariableInsn = ramRomAccessSubroutine + (romRomAccessSubro
             LDX #&00
             LDA #opcodeStaAbs
 .LBF76      STA ramRomAccessSubroutineVariableInsn
-            LDA prv82+&00,X
+            LDA SFTODOABLOW,X
             STA ramRomAccessSubroutineVariableInsn + 1
-            LDA prv82+&01,X
+            LDA SFTODOABMID,X
             STA ramRomAccessSubroutineVariableInsn + 2
-            LDY prv82+&02,X
+            LDY SFTODOABHIGH,X
             LDA prv83+&18,Y
             TAY
             PLA
@@ -8919,14 +8932,14 @@ ramRomAccessSubroutineVariableInsn = ramRomAccessSubroutine + (romRomAccessSubro
 .purgePrintBuffer
 {
 .LBF90      LDA #&00
-            STA prv82+&00
-            STA prv82+&03
+            STA SFTODOALOW
+            STA SFTODOBLOW
             LDA prv82+&0C
-            STA prv82+&01
-            STA prv82+&04
+            STA SFTODOAMID
+            STA SFTODOBMID
             LDA prv82+&0D
-            STA prv82+&02
-            STA prv82+&05
+            STA SFTODOAHIGH
+            STA SFTODOBHIGH
             LDA prvPrintBufferSizeLow
             STA prvPrintBufferFreeLow
             LDA prvPrintBufferSizeMid

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -5057,7 +5057,7 @@ GUARD	&C000
 .LA380      LDX L00AA								;get ROM number
             JSR L9FC6								;check if ROM is WP. Will return with Z set if writeable
             PHP
-            LDA #&45								;'E' (Enabled)
+            LDA #'E'								;'E' (Enabled)
             PLP
             BEQ LA38D								;jump to write to screen
             LDA #&50								;'P' (Protected)
@@ -5065,7 +5065,7 @@ GUARD	&C000
             JSR PrvEn								;switch in private RAM
             LDX L00AA								;Get ROM Number
             LDA L02A1,X								;get ROM Type
-            LDY #&20								;' '
+            LDY #' '								;' '
             AND #&FE								;bit 0 of ROM Type is undefined, so mask out
             BNE LA3BC								;if any other bits set, then ROM exists so skip code for Unplugged ROM check, and get and write ROM details
             LDY #&55								;'U' (Unplugged)
@@ -5076,18 +5076,18 @@ GUARD	&C000
             JSR L91B9								;write ' ' to screen in place of 'U'
             JSR L91B9								;write ' ' to screen in place of 'S'
             JSR L91B9								;write ' ' to screen in place of 'L'
-            LDA #&29								;')'
+            LDA #')'								;')'
             JSR OSWRCH								;write to screen
             JMP OSNEWL								;new line and return
 			
 .LA3BC      PHA									;save ROM Type
             TYA									;either ' ' for inserted, or 'U' for unplugged, depending on where called from
             JSR OSWRCH								;write to screen
-            LDX #&53								;'S' (Service)
+            LDX #'S'								;'S' (Service)
             PLA									;recover ROM Type
             PHA									;save ROM Type for further investigation
             BMI LA3C9								;check bit 7 (Service Entry exists) and write 'S' if set
-            LDX #&20								;otherwise write ' '
+            LDX #' '								;otherwise write ' '
 .LA3C9      TXA
             JSR OSWRCH								;write either 'S' or ' ' to screen
             LDX #&4C								;'L' (Language)
@@ -6167,7 +6167,7 @@ GUARD	&C000
             BCS LAC1F
 .LAC1D      LDA #&0C								;get '0C'
 .LAC1F      JSR LAB3C								;convert to characters, store in buffer XY?Y, increase buffer pointer, save buffer pointer and return
-            LDA #&3A								;':'
+            LDA #':'								;':'
             JSR LABE2								;save the contents of A to buffer address + buffer address offset, then increment buffer address offset
 .LAC27      LDX #&00
             LDA L00AB

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -8761,10 +8761,11 @@ ibosCNPVIndex = 6
 }
             PLP
             RTS
-			
-.LBEB2      LDX #&03
-            BNE LBEB8
-.LBEB6      LDX #&00
+
+{
+.^LBEB2     LDX #&03
+            BNE LBEB8 ; always branch
+.^LBEB6     LDX #&00
 .LBEB8      INC prv82+&00,X
             BNE LBEE8
             INC prv82+&01,X
@@ -8786,6 +8787,7 @@ ibosCNPVIndex = 6
             LDA prv82+&0C
             STA prv82+&01,X
 .LBEE8      RTS
+}
 
 ; SFTODO: This has only one caller
 ; Return with carry set if and only if the printer buffer is full.

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -8586,7 +8586,7 @@ ibosCNPVIndex = 6
 
 .insvBufferNotFull
 .LBD7E      LDA L0108,X ; get original A=character to insert
-            JSR LBF71
+            JSR staArbitraryRom
             JSR LBEB6
             JSR LBF43
             ; Return to caller with carry clear to indicate insertion succeeded.
@@ -8622,7 +8622,7 @@ ibosCNPVIndex = 6
 .LBDB8      LDA L0107,X
             AND #&FE
             STA L0107,X
-            JSR LBF6A
+            JSR ldaArbitraryRom
             TSX
             PHA
             LDA L0107,X
@@ -8889,11 +8889,16 @@ ramRomAccessSubroutineVariableInsn = ramRomAccessSubroutine + (romRomAccessSubro
             STX SHEILA+&30			;relocates to &038C
             RTS				;relocates to &038F
 .romRomAccessSubroutineEnd
-			
+
+; Temporarily page in ROM bank at &8318+?&8205 and do LDA (&8203)
+.ldaArbitraryRom
+{
 .LBF6A      PHA
             LDX #&03
-            LDA #&AD
-            BNE LBF76
+            LDA #opcodeLdaAbs
+            BNE LBF76 ; always branch
+; Temporarily page in ROM bank at &8318+?&8202 and do STA (&8200)
+.^staArbitraryRom
 .LBF71      PHA
             LDX #&00
             LDA #opcodeStaAbs
@@ -8907,6 +8912,7 @@ ramRomAccessSubroutineVariableInsn = ramRomAccessSubroutine + (romRomAccessSubro
             TAY
             PLA
             JMP ramRomAccessSubroutine
+}
 
 .purgePrintBuffer
 {

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -8558,7 +8558,7 @@ ibosCNPVIndex = 6
 .LBD69      JSR pageInPrvs81
             PHA
             TSX
-            JSR LBEE9
+            JSR checkPrinterBufferEmpty
             BCC LBD7E
             LDA L0107,X
             ORA #&01
@@ -8762,6 +8762,11 @@ ibosCNPVIndex = 6
             STA prv82+&01,X
 .LBEE8      RTS
 
+; SFTODO: This has only one caller
+; Return with carry set if printer buffer is enabled (SFTODO?) and empty.
+; SFTODO: Not 100% confident I have the meaning of the return value correct yet
+.checkPrinterBufferEmpty
+{
 .LBEE9      LDA prvPrinterBufferUsedLow
             ORA prvPrinterBufferUsedHigh
             ORA prvPrinterBufferStatus
@@ -8771,6 +8776,7 @@ ibosCNPVIndex = 6
 			
 .LBEF6      SEC
             RTS
+}
 			
 .LBEF8      LDA prvPrinterBufferUsedLow
             CMP prv82+&09
@@ -8800,6 +8806,7 @@ ibosCNPVIndex = 6
             LDY prvPrinterBufferUsedHigh
             RTS
 
+            ; SFTODO: Why do we return &FFFF here? Isn't that saying the buffer has 64K free?
 .LBF20      LDX #&FF
             LDY #&FF
             RTS

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -1927,7 +1927,9 @@ GUARD	&C000
 .L8C6D      JMP OSWRCH
 
 ;*PURGE Command
-.purge      JSR L8699
+.purge
+{
+            JSR L8699
             BCC L8C8F
             LDA (L00A8),Y
             CMP #&3F
@@ -1940,10 +1942,11 @@ GUARD	&C000
 .L8C86      JSR PrvEn								;switch in private RAM
             JSR purgePrintBuffer
             JMP L8E0A
-			
+
 .L8C8F      LDX #&47
             JSR L8864								;write data to Private RAM &83xx (Addr = X, Data = A)
             JMP exitSC								;Exit Service Call
+}
 			
 ;*BUFFER Command
 ;Note Buffer does not work in OSMODE 0

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -8653,7 +8653,7 @@ ibosCNPVIndex = 6
             AND #flagC
             BNE cnpvCountSpaceLeft
             ; We're counting the entries in the buffer; return them as 16-bit value YX.
-            JSR LBF25
+            JSR getPrintBufferUsed
             TXA
             TSX
             STA L0103,X ; overwrite stacked X, so we return A to caller in X
@@ -8800,7 +8800,10 @@ ibosCNPVIndex = 6
             LDY #&FF
             RTS
 }
-			
+
+; SFTODO: Currently has only one caller FWIW
+.getPrintBufferUsed
+{
 .LBF25      SEC
             LDA prv82+&09
             SBC prv82+&06
@@ -8809,6 +8812,7 @@ ibosCNPVIndex = 6
             SBC prv82+&07
             TAY
             RTS
+}
 
 .LBF35      INC prv82+&06
             BNE LBF3D

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -8555,7 +8555,7 @@ ibosCNPVIndex = 6
             LDA L0107,X
             ORA #&01
             STA L0107,X
-            JMP LBDDD
+            JMP setRamselAClearPrvenReturnFromVectorHandler
 }
 			
 .LBD7E      LDA L0108,X
@@ -8566,7 +8566,7 @@ ibosCNPVIndex = 6
             LDA L0107,X
             AND #&FE
             STA L0107,X
-            JMP LBDDD
+            JMP setRamselAClearPrvenReturnFromVectorHandler
 
 ; SFTODO: Would it be possible to factor out the common-ish code at the start of
 ; insvHandler/remvHandler/cnpvHandler to save space?
@@ -8587,7 +8587,7 @@ ibosCNPVIndex = 6
             LDA L0107,X
             ORA #&01
             STA L0107,X
-            JMP LBDDD
+            JMP setRamselAClearPrvenReturnFromVectorHandler
 }
 			
 .LBDB8      LDA L0107,X
@@ -8603,11 +8603,14 @@ ibosCNPVIndex = 6
             STA L0108,X
             JSR LBEB2
             JSR LBF35
-            JMP LBDDD
+            JMP setRamselAClearPrvenReturnFromVectorHandler
 			
 .LBDD9      PLA
             STA L0102,X
-; Set RAMSEL to A and clear PRVEN SFTODO: then do some stack return-looking stuff at B9E9 - take that into account when giving meaningful label here
+; Set RAMSEL to A and clear PRVEN, then return from the vector handler.
+; SFTODO: Perhaps not the catchiest label name ever...
+.setRamselAClearPrvenReturnFromVectorHandler
+{
 .LBDDD      PLA
             STA &037F
             STA SHEILA+&34
@@ -8616,6 +8619,7 @@ ibosCNPVIndex = 6
             STA &F4
             STA SHEILA+&30
             JMP returnFromVectorHandler
+}
 
 .cnpvHandler
 {
@@ -8637,7 +8641,7 @@ ibosCNPVIndex = 6
             JSR L8870								;read data from Private RAM &83xx (Addr = X, Data = A)
             BEQ LBE16
             JSR LBF90
-.LBE16      JMP LBDDD
+.LBE16      JMP setRamselAClearPrvenReturnFromVectorHandler
 }
 
 .LBE19      LDA L0107,X
@@ -8649,7 +8653,7 @@ ibosCNPVIndex = 6
             STA L0103,X
             TYA
             STA L0102,X
-            JMP LBDDD
+            JMP setRamselAClearPrvenReturnFromVectorHandler
 			
 .LBE2F      JSR LBF14
             TXA
@@ -8657,7 +8661,7 @@ ibosCNPVIndex = 6
             STA L0103,X
             TYA
             STA L0102,X
-            JMP LBDDD
+            JMP setRamselAClearPrvenReturnFromVectorHandler
 			
 .LBE3E      LDX L028D
             BEQ LBE7B

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -8026,7 +8026,10 @@ ibosCNPVIndex = 6
 		EQUB &01								;OSMODE 6 - No such mode
 		EQUB &01								;OSMODE 7 - No such mode
 
+.jmpParentBYTEV
+{
 .LBA65      JMP (parentBYTEV)
+}
 
 .bytevHandler
 {
@@ -8054,7 +8057,7 @@ ibosCNPVIndex = 6
 .LBA90      JSR LB948
             JMP LBB1C
 			
-.LBA96      JSR LBA65
+.LBA96      JSR jmpParentBYTEV
             BCS LBACB
             LDA &037F
             PHA
@@ -8126,7 +8129,7 @@ ibosCNPVIndex = 6
 .LBB18      PLA
             TAX
             LDA #&00
-.LBB1C      JSR LBA65
+.LBB1C      JSR jmpParentBYTEV
             JMP LBACB
 			
 .LBB22      LDX #&00								;start at offset 0

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -8652,23 +8652,26 @@ ibosCNPVIndex = 6
 .LBE19      LDA L0107,X ; get original flags
             AND #flagC
             BNE cnpvCountSpaceLeft
-            ; We're counting the entries in the buffer.
+            ; We're counting the entries in the buffer; return them as 16-bit value YX.
             JSR LBF25
             TXA
             TSX
-            STA L0103,X
+            STA L0103,X ; overwrite stacked X, so we return A to caller in X
             TYA
-            STA L0102,X
+            STA L0102,X ; overwrite stacked Y, so we return A to caller in Y
             JMP setRamselAClearPrvenReturnFromVectorHandler
 }
 
 .cnpvCountSpaceLeft
+            ; We're counting the space left in the buffer; return that as 16-bit value YX.
 .LBE2F      JSR LBF14
+            ; SFTODO: Following code is identical to fragment just above, we
+            ; could JMP to it to avoid this duplication.
             TXA
             TSX
-            STA L0103,X
+            STA L0103,X ; overwrite stacked X, so we return A to caller in X
             TYA
-            STA L0102,X
+            STA L0102,X ; overwrite stacked Y, so we return A to caller in Y
             JMP setRamselAClearPrvenReturnFromVectorHandler
 			
 .LBE3E      LDX L028D

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -8663,8 +8663,9 @@ ibosCNPVIndex = 6
 }
 
 .cnpvCountSpaceLeft
+{
             ; We're counting the space left in the buffer; return that as 16-bit value YX.
-.LBE2F      JSR LBF14
+.LBE2F      JSR getPrintBufferFree
             ; SFTODO: Following code is identical to fragment just above, we
             ; could JMP to it to avoid this duplication.
             TXA
@@ -8673,6 +8674,7 @@ ibosCNPVIndex = 6
             TYA
             STA L0102,X ; overwrite stacked Y, so we return A to caller in Y
             JMP setRamselAClearPrvenReturnFromVectorHandler
+}
 			
 .LBE3E      LDX L028D
             BEQ LBE7B
@@ -8780,7 +8782,14 @@ ibosCNPVIndex = 6
 			
 .LBF12      CLC
             RTS
-			
+
+; SFTODO: This currently only has one caller, so could be inlined. Although
+; maybe there's some critical alignment stuff going on, which means certain code
+; has to live in the &Bxxx region so it can be accessed while private RAM is
+; paged in. But we could potentially move the caller (or just all INSV/CNPV/REMV
+; code??) into &Bxxx, although it may not be worth the hassle.
+.getPrintBufferFree
+{
 .LBF14      LDX prv82+&08
             BNE LBF20
             LDX prv82+&06
@@ -8790,6 +8799,7 @@ ibosCNPVIndex = 6
 .LBF20      LDX #&FF
             LDY #&FF
             RTS
+}
 			
 .LBF25      SEC
             LDA prv82+&09
@@ -8893,7 +8903,7 @@ SAVE "IBOS-01.rom", start, end
 ; labels, but I'm keeping them around for now as they might come in handy and
 ; it's much easier to take them out than to put them back in...
 
-; SFTODO: Is there any reason we can't always page the private RAM in and out as
-; a 12K chunk? If we don't need the fine-grained control on offer, we might be
-; able to remove some subroutines to page in/out different chunks and free up
-; some space for other code.
+; SFTODO: The original ROM obviously has everything aligned correctly, but if
+; we're going to be modifying this in the future it might be good to put
+; asserts in routines which have to live outside a certain area of the ROM in
+; order to avoid breaking when we page in private RAM.

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -272,6 +272,7 @@ prvPrintBufferFreeHigh = prv82 + &08
 prvPrintBufferSizeLow  = prv82 + &09
 prvPrintBufferSizeMid  = prv82 + &0A
 prvPrintBufferSizeHigh = prv82 + &0B
+prvPrintBufferBankList = prv83 + &18 ; 4 bytes
 
 LDBE6       = &DBE6
 LDC16       = &DC16
@@ -2006,7 +2007,7 @@ GUARD	&C000
 .L8CD8      JSR L8E10								;test for SWRAM at bank Y
             BCS L8CE6
             TYA
-            STA prv83+&18,X								;store RAM bank number in Private memory
+            STA prvPrintBufferBankList,X								;store RAM bank number in Private memory
             INX									;increment counter for number of RAM banks found
             CPX #&04								;until 4 banks are found
             BEQ L8CEB
@@ -2022,7 +2023,7 @@ GUARD	&C000
             LDA #&FF
 .L8CF7      CPX #&04
             BCS L8D01
-            STA prv83+&18,X
+            STA prvPrintBufferBankList,X
             INX
             BNE L8CF7
 .L8D01      JSR L8D5A
@@ -2041,7 +2042,7 @@ GUARD	&C000
             TYA
             BCS L8D2C
             LDX L00AC
-            STA prv83+&18,X
+            STA prvPrintBufferBankList,X
             INX
             STX L00AC
             CPX #&04
@@ -2053,7 +2054,7 @@ GUARD	&C000
             JMP L8DCA
 			
 .L8D37      LDA #&FF								;unassign RAM banks from *BUFFER
-            STA prv83+&18
+            STA prvPrintBufferBankList
             STA prv83+&19
             STA prv83+&1A
             STA prv83+&1B
@@ -2063,12 +2064,12 @@ GUARD	&C000
 .L8D46      LDA &F4
             AND #&0F
             ORA #&40
-            STA prv83+&18
+            STA prvPrintBufferBankList
             LDA #&FF
             STA prv83+&19
             STA prv83+&1A
             STA prv83+&1B
-.L8D5A      LDA prv83+&18
+.L8D5A      LDA prvPrintBufferBankList
             CMP #&FF
             BEQ L8D46
             AND #&F0
@@ -2094,7 +2095,7 @@ GUARD	&C000
             STA prvPrintBufferSizeMid
             STA prvPrintBufferSizeHigh
             TAX
-.L8D99      LDA prv83+&18,X
+.L8D99      LDA prvPrintBufferBankList,X
             BMI L8DB5
             CLC
             LDA prvPrintBufferSizeMid
@@ -2123,7 +2124,7 @@ GUARD	&C000
             ROR A
             SEC									;left justify (ignore leading 0s)
             JSR L86DE								;Convert binary number to numeric characters and write characters to screen
-            LDA prv83+&18
+            LDA prvPrintBufferBankList
             AND #&F0
             CMP #&40
             BNE L8DE8
@@ -2134,7 +2135,7 @@ GUARD	&C000
 .L8DE8      LDX #&01								;starting with the first RAM bank
             JSR L8E8C								;write 'k in Shadow RAM '
             LDY #&00
-.L8DEF      LDA prv83+&18,Y								;get RAM bank number from Private memory
+.L8DEF      LDA prvPrintBufferBankList,Y								;get RAM bank number from Private memory
             BMI L8E02								;if nothing in private memory then finish, otherwise
             SEC									;left justify (ignore leading 0s)
             JSR L86DE								;Convert binary number to numeric characters and write characters to screen
@@ -8733,7 +8734,7 @@ ibosCNPVIndex = 6
             STA prvPrintBufferSizeMid
             LDA &F4
             ORA #&40
-            STA prv83+&18
+            STA prvPrintBufferBankList
             LDA #&FF
             STA prv83+&19
             STA prv83+&1A
@@ -8790,7 +8791,7 @@ ibosCNPVIndex = 6
             CPY #&04
             BCC LBED2
             LDY #&00
-.LBED2      LDA prv83+&18,Y
+.LBED2      LDA prvPrintBufferBankList,Y
             BPL LBED9
             LDY #&00
 .LBED9      TYA
@@ -8923,7 +8924,7 @@ ramRomAccessSubroutineVariableInsn = ramRomAccessSubroutine + (romRomAccessSubro
             LDA SFTODOABMID,X
             STA ramRomAccessSubroutineVariableInsn + 2
             LDY SFTODOABHIGH,X
-            LDA prv83+&18,Y
+            LDA prvPrintBufferBankList,Y
             TAY
             PLA
             JMP ramRomAccessSubroutine

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -8003,9 +8003,9 @@ ibosCNPVIndex = 6
 
 ; SFTODO: What's this doing?
 .LBA3A      CPX #&00
-            BNE LBA90
+            BNE osbyte87Handler
             CPY #&FF
-            BNE LBA90
+            BNE osbyte87Handler
             LDX #&3C								;select OSMODE
             JSR L8870								;read data from Private RAM &83xx (Addr = X, Data = A)
             BEQ LBA56								;Branch if OSMODE=0
@@ -8048,9 +8048,9 @@ ibosCNPVIndex = 6
             CMP #&98
             BEQ osbyte98Handler
             CMP #&87
-            BEQ LBA90
+            BEQ osbyte87Handler
             CMP #&84
-            BEQ LBAD1
+            BEQ osbyte84Handler
             CMP #&85
             BEQ LBADC
             CMP #&8E
@@ -8062,9 +8062,13 @@ ibosCNPVIndex = 6
             LDA #ibosBYTEVIndex
             JMP returnToParentVectorTblEntry
 }
-			
+
+; Read character at text cursor and screen mode (http://beebwiki.mdfs.net/OSBYTE_%2687)
+.osbyte87Handler
+{
 .LBA90      JSR LB948
             JMP LBB1C
+}
 
 ; Examine buffer status (http://beebwiki.mdfs.net/OSBYTE_%2698)
 .osbyte98Handler
@@ -8098,12 +8102,15 @@ ibosCNPVIndex = 6
 .LBACB      JSR LB9AA
             JMP LB9E9
 
+.osbyte84Handler
+{
 .LBAD1      PHA
             LDA L00D0
             AND #&10
             BNE LBAE9
             PLA
             JMP LBB1C
+}
 			
 .LBADC      PHA
             TXA

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -8001,7 +8001,9 @@ ibosCNPVIndex = 6
             JMP LBACB
 }
 
-; SFTODO: What's this doing?
+; Read key with time limit/read machine type (http://beebwiki.mdfs.net/OSBYTE_%2681)
+.osbyte81Handler
+{
 .LBA3A      CPX #&00
             BNE osbyte87Handler
             CPY #&FF
@@ -8019,6 +8021,7 @@ ibosCNPVIndex = 6
 .LBA56      LDX #&00
             LDA #&81
             JMP LBB1C								;jump to code for OSMODE 0-1
+}
 			
 ;OSMODE lookup table
 .LBA5D		EQUB &01								;OSMODE 0 - Not Used
@@ -8058,7 +8061,7 @@ ibosCNPVIndex = 6
             CMP #&00
             BEQ osbyte00Handler
             CMP #&81
-            BEQ LBA3A
+            BEQ osbyte81Handler
             LDA #ibosBYTEVIndex
             JMP returnToParentVectorTblEntry
 }
@@ -8141,6 +8144,7 @@ ibosCNPVIndex = 6
             JMP LBB1C
 }
 
+; Identify host/operating system (http://beebwiki.mdfs.net/OSBYTE_%2600)
 .osbyte00Handler
 {
 .LBB00      TXA

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -250,6 +250,10 @@ prv81       = &8100
 prv82       = &8200
 prv83       = &8300
 
+prvPrinterBufferUsedLow  = prv82 + &06
+prvPrinterBufferUsedHigh = prv82 + &07
+prvPrinterBufferStatus   = prv82 + &08 ; SFTODO: what are possible values?
+
 LDBE6       = &DBE6
 LDC16       = &DC16
 LF168       = &F168
@@ -8758,9 +8762,9 @@ ibosCNPVIndex = 6
             STA prv82+&01,X
 .LBEE8      RTS
 
-.LBEE9      LDA prv82+&06
-            ORA prv82+&07
-            ORA prv82+&08
+.LBEE9      LDA prvPrinterBufferUsedLow
+            ORA prvPrinterBufferUsedHigh
+            ORA prvPrinterBufferStatus
             BEQ LBEF6
             CLC
             RTS
@@ -8768,13 +8772,13 @@ ibosCNPVIndex = 6
 .LBEF6      SEC
             RTS
 			
-.LBEF8      LDA prv82+&06
+.LBEF8      LDA prvPrinterBufferUsedLow
             CMP prv82+&09
             BNE LBF12
-            LDA prv82+&07
+            LDA prvPrinterBufferUsedHigh
             CMP prv82+&0A
             BNE LBF12
-            LDA prv82+&07
+            LDA prvPrinterBufferUsedHigh
             CMP prv82+&0A
             BNE LBF12
             SEC
@@ -8790,10 +8794,10 @@ ibosCNPVIndex = 6
 ; code??) into &Bxxx, although it may not be worth the hassle.
 .getPrintBufferFree
 {
-.LBF14      LDX prv82+&08
+.LBF14      LDX prvPrinterBufferStatus
             BNE LBF20
-            LDX prv82+&06
-            LDY prv82+&07
+            LDX prvPrinterBufferUsedLow
+            LDY prvPrinterBufferUsedHigh
             RTS
 
 .LBF20      LDX #&FF
@@ -8806,30 +8810,30 @@ ibosCNPVIndex = 6
 {
 .LBF25      SEC
             LDA prv82+&09
-            SBC prv82+&06
+            SBC prvPrinterBufferUsedLow
             TAX
             LDA prv82+&0A
-            SBC prv82+&07
+            SBC prvPrinterBufferUsedHigh
             TAY
             RTS
 }
 
-.LBF35      INC prv82+&06
+.LBF35      INC prvPrinterBufferUsedLow
             BNE LBF3D
-            INC prv82+&07
+            INC prvPrinterBufferUsedHigh
 .LBF3D      BNE LBF42
-            INC prv82+&08
+            INC prvPrinterBufferStatus
 .LBF42      RTS
 
 .LBF43      SEC
-            LDA prv82+&06
+            LDA prvPrinterBufferUsedLow
             SBC #&01
-            STA prv82+&06
-            LDA prv82+&07
+            STA prvPrinterBufferUsedLow
+            LDA prvPrinterBufferUsedHigh
             SBC #&00
-            STA prv82+&07
+            STA prvPrinterBufferUsedHigh
             BCS LBF59
-            DEC prv82+&08
+            DEC prvPrinterBufferStatus
 .LBF59      RTS
 
 ;code relocated to &0380
@@ -8871,11 +8875,11 @@ ibosCNPVIndex = 6
             STA prv82+&02
             STA prv82+&05
             LDA prv82+&09
-            STA prv82+&06
+            STA prvPrinterBufferUsedLow
             LDA prv82+&0A
-            STA prv82+&07
+            STA prvPrinterBufferUsedHigh
             LDA prv82+&0B
-            STA prv82+&08
+            STA prvPrinterBufferStatus
             RTS
 			
 .LBFBD      LDX #&45

--- a/IBOS.asm
+++ b/IBOS.asm
@@ -8056,7 +8056,7 @@ ibosCNPVIndex = 6
             CMP #&8E
             BEQ osbyte8EHandler
             CMP #&00
-            BEQ LBB00
+            BEQ osbyte00Handler
             CMP #&81
             BEQ LBA3A
             LDA #ibosBYTEVIndex
@@ -8140,7 +8140,9 @@ ibosCNPVIndex = 6
             JSR LB994
             JMP LBB1C
 }
-			
+
+.osbyte00Handler
+{
 .LBB00      TXA
             PHA
             LDX #&3C								;select OSMODE
@@ -8154,6 +8156,7 @@ ibosCNPVIndex = 6
             BEQ LBB22								;Output OSMODE to screen.
             LDA #&00
             JMP LBACB
+}
 			
 .LBB18      PLA
             TAX

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ IBOS-01.rom: IBOS.asm Makefile
 	@cmp IBOS-01.rom IBOS-Orig.rom || (echo "New ROM is not identical to original"; mv IBOS-01.rom IBOS-01-variant.rom; exit 1)
 
 clean:
-	/bin/rm -f IBOS.lst IBOS-01.rom
+	/bin/rm -f IBOS.lst IBOS-01.rom IBOS-01-variant.rom

--- a/commit.sh
+++ b/commit.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+make && git commit -av -m "Improve disassembly (output unchanged)"


### PR DESCRIPTION
Hi Ken,

More annotations. The printer buffer code is starting to emerge from the fog, although there's still an awful lot I don't understand yet.

Just a random thought: if you did need to free up space in the ROM for your improvements, would jettisoning the printer buffer support be acceptable? (But I still want to disassemble it and get the unmodified ROM nicely documented regardless.) I don't see much talk about using printers attached to Acorn machines on stardot and this could free up a fair chunk of ROM space.

But it would certainly be nicer not to have to remove any functionality, of course. I've found a few places in the code where there might be optimisation potential, and (without going back to your e-mail to check) I'm not sure your proposed changes would require all that much code, so just maybe it could all be done in 16K anyway. (And of course there's always the PALPROM option.)

Anyway, this is just random mutterings. Please have a look over these changes, and if you have any suggestions on the half-documented stuff let me know. I'll probably do some more on this tomorrow.

Cheers.

Steve